### PR TITLE
fix: use parseAsync insted of resolving parse

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -31,7 +31,7 @@ export function toFormikValidationSchema<T>(
   return {
     async validate(obj: T) {
       try {
-        await Promise.resolve(schema.parse(obj));
+        await schema.parseAsync(obj);
       } catch (err: unknown) {
         throw createValidationError(err as z.ZodError<T>);
       }


### PR DESCRIPTION
zod operations like async refine rely on parseAsync