### PR TITLE
feat: add toFormikValidate function

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![codecov](https://codecov.io/gh/robertLichtnow/zod-formik-adapter/branch/master/graph/badge.svg?token=Z5V1VKCGV9)](https://codecov.io/gh/robertLichtnow/zod-formik-adapter)
 
-This library adapts a [zod](https://www.npmjs.com/package/zod) schema to work as a `validationSchema` prop on [Formik](https://www.npmjs.com/package/formik)
+This library adapts a [zod](https://www.npmjs.com/package/zod) schema to work as a `validationSchema` prop or `validate` prop on [Formik](https://www.npmjs.com/package/formik)
 
 **IMPORTANT: Currently, this library does not work with zod union. See more [here](https://github.com/robertLichtnow/zod-formik-adapter/issues/2).**
 
@@ -31,6 +31,25 @@ const Schema = z.object({
 const Component = () => (
   <Formik
     validationSchema={toFormikValidationSchema(Schema)}
+  >
+    {...}
+  </Formik>
+);
+```
+
+```TSX
+import { z } from 'zod';
+import { Formik } from 'formik';
+import { toFormikValidate } from 'zod-formik-adapter';
+
+const Schema = z.object({
+  name: z.string(),
+  age: z.number(),
+});
+
+const Component = () => (
+  <Formik
+    validate={toFormikValidate(Schema)}
   >
     {...}
   </Formik>

--- a/index.ts
+++ b/index.ts
@@ -39,3 +39,30 @@ export function toFormikValidationSchema<T>(
     },
   };
 }
+
+function createValidationResult(error: z.ZodError) {
+  const result: Record<string, string> = {};
+
+  for (const x of error.errors) {
+    result[x.path.filter(Boolean).join(".")] = x.message;
+  }
+
+  return result;
+}
+
+/**
+ * Wrap your zod schema in this function when providing it to Formik's validate prop
+ * @param schema The zod schema
+ * @returns An validate function as expected by Formik
+ */
+export function toFormikValidate<T>(
+  schema: z.ZodSchema<T>,
+  params?: Partial<z.ParseParams>
+) {
+  return async (values: T) => {
+    const result = await schema.safeParseAsync(values, params);
+    if (!result.success) {
+      return createValidationResult(result.error);
+    }
+  };
+}

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { toFormikValidationSchema, ValidationError } from '../index';
+import { toFormikValidationSchema, toFormikValidate } from '../index';
 
 describe("toFormikValidationSchema", () => {
   it("should pass validate without errors", async () => {
@@ -37,6 +37,39 @@ describe("toFormikValidationSchema", () => {
     await expect(
       validate(object),
     ).rejects.toMatchObject(error);
+  });
+});
+
+describe("toFormikValidate", () => {
+  it("should pass validate without errors", async () => {
+    // given
+    const object = { name: "mock", age: 32 };
+    const { schema } = makeSut();
+    const validate = toFormikValidate(schema);
+    
+    // when
+    const errors = await validate(object);
+
+    // then
+    expect(errors).toEqual(undefined);
+  });
+
+  it("should fail validate with error object", async () => {
+    // given
+    const object = { name: undefined, age: "32" } as any;
+    const { schema } = makeSut();
+    const validate = toFormikValidate(schema);
+
+    const error = {
+      name: "Required",
+      age: "Expected number, received string"
+    };
+
+    // when
+    const errors = await validate(object)
+
+    // then
+    expect(errors).toMatchObject(error);
   });
 });
 


### PR DESCRIPTION
This provides a new function `toFormikValidate` that will generate a `validate` function as `Formik` expects it.

This supports root union types with the caveat that the root error message will be passed as property `""` of the error object:

```ts
const rootUnionErrorMessage = error[''];
```

This can be a work around for https://github.com/robertLichtnow/zod-formik-adapter/issues/2

[CodeSandbox](https://codesandbox.io/s/headless-night-tlyz19?file=/src/App.tsx)
