### PR TITLE
Remove `react` peer dep + expand `zod` support

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,11 @@
     "semantic-release": "^17.4.5",
     "ts-jest": "^27.0.4",
     "typescript": "~4.6.3",
-    "zod": "~3.14.4"
+    "zod": "^3.14.4"
   },
   "peerDependencies": {
     "formik": "^2.2.9",
-    "react": "^17.0.2",
-    "zod": "~3.14.4"
+    "zod": "^3.14.4"
   },
   "jest": {
     "coverageDirectory": "./coverage/",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5503,7 +5503,7 @@ yargs@^16.0.3, yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-zod@~3.14.4:
-  version "3.14.4"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.14.4.tgz#e678fe9e5469f4663165a5c35c8f3dc66334a5d6"
-  integrity sha512-U9BFLb2GO34Sfo9IUYp0w3wJLlmcyGoMd75qU9yf+DrdGA4kEx6e+l9KOkAlyUO0PSQzZCa3TR4qVlcmwqSDuw==
+zod@^3.14.4:
+  version "3.19.1"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.19.1.tgz#112f074a97b50bfc4772d4ad1576814bd8ac4473"
+  integrity sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==


### PR DESCRIPTION
Hi @robertLichtnow! I have some small changes to improve experience using `zod-formik-adapter` ...

1. [The adapter](https://github.com/robertLichtnow/zod-formik-adapter/blob/593d4f8ecbcf9898548733f51012ff85b9596576/index.ts) doesn't depend on **React** & **Formik** already specifies that as a peer dependency (`>=16.8.0`)
2. [The **Zod** peer dep](https://github.com/robertLichtnow/zod-formik-adapter/blob/593d4f8ecbcf9898548733f51012ff85b9596576/package.json#L31) is locked to `3.14.x` patch versions when tests pass on latest `3.19.1` minor version