### PR TITLE
Remove warning about unions being broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 This library adapts a [zod](https://www.npmjs.com/package/zod) schema to work as a `validationSchema` prop or `validate` prop on [Formik](https://www.npmjs.com/package/formik)
 
-**IMPORTANT: Currently, this library does not work with zod union. See more [here](https://github.com/robertLichtnow/zod-formik-adapter/issues/2).**
-
 ## Install
 
 ```sh


### PR DESCRIPTION
This pull request makes a change to the README.md, removing the warning about using unions. The issue linked seems to be closed/resolved.

https://github.com/robertLichtnow/zod-formik-adapter/issues/2