### PR TITLE
update zod for security fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "semantic-release": "^17.4.5",
     "ts-jest": "^27.0.4",
     "typescript": "~4.6.3",
-    "zod": "^3.14.4"
+    "zod": "^3.22.4"
   },
   "peerDependencies": {
     "formik": "^2.2.9",
-    "zod": "^3.14.4"
+    "zod": "^3.22.4"
   },
   "jest": {
     "coverageDirectory": "./coverage/",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5503,7 +5503,7 @@ yargs@^16.0.3, yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-zod@^3.14.4:
-  version "3.19.1"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.19.1.tgz#112f074a97b50bfc4772d4ad1576814bd8ac4473"
-  integrity sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==
+zod@^3.22.4:
+  version "3.22.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
+  integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==


### PR DESCRIPTION
This PR updates zod to [fix a security issue](https://nvd.nist.gov/vuln/detail/CVE-2023-4316).